### PR TITLE
add UK: unknown_tag to output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ Complete default mapping
      'TI': 'title',
      'TT': 'translated_title',
      'TY': 'type_of_reference',
+     'UK': 'unknown_tag',
      'UR': 'url',
      'VL': 'volume',
      'Y1': 'publication_year',

--- a/RISparser/__init__.py
+++ b/RISparser/__init__.py
@@ -9,7 +9,7 @@ __version__ = "0.4.2"
 # to be incremented manually
 # automatically parsed by setup.py
 
-
+from collections import defaultdict
 import re
 
 from .config import LIST_TYPE_TAGS, TAG_KEY_MAPPING
@@ -77,8 +77,10 @@ class Base(object):
         if tag in self.mapping:
             self.add_tag(tag, line)
             raise NextLine
+        else:
+            self.add_unknown_tag(tag, line)
+            raise NextLine
 
-        print("RIS Ignored:", line)
         raise NextLine
 
     def parse_other(self, line, line_number):
@@ -124,6 +126,16 @@ class Base(object):
             return
 
         self.add_list_value(name, new_value)
+
+    def add_unknown_tag(self, tag, line):
+        name = self.mapping['UK']
+        tag = self.get_tag(line)
+        value = self.get_content(line)
+        # check if unknown_tag dict exists
+        if name not in self.current:
+            self.current[name] = defaultdict(list)
+
+        self.current[name][tag].append(value)
 
     def get_tag(self, line):
         return line[0:2]

--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -74,6 +74,7 @@ TAG_KEY_MAPPING = {
     'Y1': "publication_year",
     'Y2': "access_date",
     'ER': "end_of_reference",
+    'UK': 'unknown_tag',
 }
 
 TYPE_OF_REFERENCE_MAPPING = {

--- a/tests/example_multi_unknown_tags.ris
+++ b/tests/example_multi_unknown_tags.ris
@@ -1,0 +1,11 @@
+TY  - JOUR
+AU  - Shannon,Claude E.
+PY  - 1948/07//
+TI  - A Mathematical Theory of Communication
+JF  - Bell System Technical Journal
+SP  - 379
+EP  - 423
+VL  - 27
+JP  - CRISPR
+DC  - Direct Current
+ER  - 

--- a/tests/example_single_unknown_tag.ris
+++ b/tests/example_single_unknown_tag.ris
@@ -1,0 +1,11 @@
+TY  - JOUR
+AU  - Shannon,Claude E.
+PY  - 1948/07//
+TI  - A Mathematical Theory of Communication
+JF  - Bell System Technical Journal
+SP  - 379
+EP  - 423
+VL  - 27
+JP  - CRISPR
+JP  - Direct Current
+ER  - 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import defaultdict
 import os
 from RISparser import readris, TAG_KEY_MAPPING
 
@@ -122,3 +123,47 @@ class TestRISparser():
         with open(filepath, 'r') as bibliography_file:
             entries = list(readris(bibliography_file))
             self.compare(results, entries)
+
+    def test_parse_single_unknown_tag_ris(self):
+        filepath = os.path.join(CURRENT_DIR, 'example_single_unknown_tag.ris')
+        unknowns = defaultdict(list)
+        unknowns['JP'].append('CRISPR')
+        unknowns['JP'].append('Direct Current')
+        result_entry = self.nice_keys({
+            'TY': 'JOUR',
+            'AU': ['Shannon,Claude E.'],
+            'PY': '1948/07//',
+            'TI': 'A Mathematical Theory of Communication',
+            'JF': 'Bell System Technical Journal',
+            'SP': '379',
+            'EP': '423',
+            'VL': '27',
+            # {'JP': ['CRISPR', 'Direct Current']}
+            'UK': unknowns,
+        })
+
+        with open(filepath, 'r') as bibliography_file:
+            entries = list(readris(bibliography_file))
+            self.compare([result_entry], entries)
+
+    def test_parse_multiple_unknown_tags_ris(self):
+        filepath = os.path.join(CURRENT_DIR, 'example_multi_unknown_tags.ris')
+        unknowns = defaultdict(list)
+        unknowns['JP'].append('CRISPR')
+        unknowns['DC'].append('Direct Current')
+        result_entry = self.nice_keys({
+            'TY': 'JOUR',
+            'AU': ['Shannon,Claude E.'],
+            'PY': '1948/07//',
+            'TI': 'A Mathematical Theory of Communication',
+            'JF': 'Bell System Technical Journal',
+            'SP': '379',
+            'EP': '423',
+            'VL': '27',
+            # {'JP': ['CRISPR'], 'DC': ['Direct Current']}
+            'UK': unknowns,
+        })
+
+        with open(filepath, 'r') as bibliography_file:
+            entries = list(readris(bibliography_file))
+            self.compare([result_entry], entries)


### PR DESCRIPTION
Prior versions of RISparser would raise an exception if a tag not in the config was parsed. This behavior was beneficial because it let us know when a user was importing unrecognized RIS data. We could then work with them to get their data in the right format.

Current behavior prints that data was ignored and then throws away the data that uses an unrecognized tag. The only time we will find out when a user is importing data using unrecognized tags is we scan the logs or if they notice that they have data missing and notify us.

This PR is for adding any unknown tags and it's data to an `unknown_tag` dict in the output.