### PR TITLE
Parse N1 fields individually

### DIFF
--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -6,6 +6,9 @@ LIST_TYPE_TAGS = [
     'AU',
     'KW',
     'N1',
+    'references',
+    'References',
+    'Funding details'
 ]
 
 
@@ -75,6 +78,12 @@ TAG_KEY_MAPPING = {
     'Y2': 'access_date',
     'ER': 'end_of_reference',
     'UK': 'unknown_tag',
+    'References': 'references',
+    'Funding details': 'funding_details',
+    'Export Date': 'export_date',
+    'Funding text': 'funding text',
+    'Correspondence Address': 'correspondence_address',
+    'CODEN': 'coden'
 }
 
 TYPE_OF_REFERENCE_MAPPING = {

--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -78,7 +78,6 @@ TAG_KEY_MAPPING = {
     'Y2': 'access_date',
     'ER': 'end_of_reference',
     'UK': 'unknown_tag',
-    'References': 'references',
     'Funding details': 'funding_details',
     'Export Date': 'export_date',
     'Funding text': 'funding text',

--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -6,7 +6,6 @@ LIST_TYPE_TAGS = [
     'AU',
     'KW',
     'N1',
-    'references',
     'References',
     'Funding details'
 ]
@@ -78,6 +77,7 @@ TAG_KEY_MAPPING = {
     'Y2': 'access_date',
     'ER': 'end_of_reference',
     'UK': 'unknown_tag',
+    'References': 'references',
     'Funding details': 'funding_details',
     'Export Date': 'export_date',
     'Funding text': 'funding text',


### PR DESCRIPTION
When working with exported RIS files, other fields such as reference lists are listed in the N1 field. I prefer to access them as fields in their own right