### PR TITLE
Fix for Wok RIS file parsing

### DIFF
--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -55,6 +55,7 @@ TAG_KEY_MAPPING = {
     'NV': 'number_of_Volumes',
     'OP': 'original_publication',
     'PB': 'publisher',
+    'PT': 'publication_type',
     'PY': 'year',
     'RI': 'reviewed_item',
     'RN': 'research_notes',

--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -8,7 +8,6 @@ LIST_TYPE_TAGS = [
     'N1',
 ]
 
-
 TAG_KEY_MAPPING = {
     'TY': 'type_of_reference',
     'A1': 'first_authors',  # ListType
@@ -134,4 +133,91 @@ TYPE_OF_REFERENCE_MAPPING = {
     'THES': 'Thesis/Dissertation',
     'UNPB': 'Unpublished work',
     'VIDEO': 'Video recording',
+}
+
+WOK_LIST_TYPE_TAGS = [
+    'RI',
+    'CR',
+    'AF',
+    'BA',
+    'BF',
+    'AU',
+    'CA',
+    'GP',
+]
+
+WOK_TAG_KEY_MAPPING = {
+    'FN': 'file_name',
+    'VR': 'version_number',
+    'PT': 'publication_type',
+    'AU': 'authors',  # ListType
+    'AF': 'author_full_name',
+    'BA': 'book_authors',
+    'BF': 'book_authors_full_name',
+    'CA': 'group_authors', # ListType
+    'GP': 'book_group_authors', # ListType
+    'BE': 'editors', # ListType
+    'TI': 'document_title',
+    'SO': 'publication_name',
+    'SE': 'book_series_title',
+    'BS': 'book_series_subtitle',
+    'LA': 'language',
+    'DT': 'document_type',
+    'CT': 'conference_title',
+    'CY': 'conference_date',
+    'CL': 'conference_location',
+    'SP': 'conference_sponsors',
+    'HO': 'conference_host',
+    'DE': 'author_keywords',
+    'ID': 'keywords_plus',
+    'AB': 'abstract',
+    'C1': 'author_address',
+    'RP': 'reprint_address',
+    'EM': 'email_address',
+    'RI': 'researcher_id',
+    'OI': 'orcid_id',
+    'FU': 'funding_agency_and_grant_number',
+    'FX': 'funding_text',
+    'CR': 'cited_references', # ListType
+    'NR': 'cited_reference_count',
+    'TC': 'wos_core_collection_cited_count',
+    'Z9': 'total_times_cited_count',
+    'U1': 'usage_count_180',
+    'U2': 'usage_count_2013',
+    'PU': 'publisher',
+    'PI': 'publisher_city',
+    'PA': 'publisher_address',
+    'SN': 'issn',
+    'EI': 'eissn',
+    'BN': 'isbn',
+    'J9': 'source_abbreviation_29c',
+    'JI': 'iso_source_abbreviation',
+    'PD': 'publication_date',
+    'PY': 'publication_year',
+    'VL': 'volume',
+    'IS': 'issue',
+    'SI': 'special_issue',
+    'PN': 'part_number',
+    'SU': 'supplement',
+    'MA': 'meeting_abstract',
+    'BP': 'beginning_page',
+    'EP': 'ending_page',
+    'AR': 'article_number',
+    'DI': 'doi',
+    'D2': 'book_doi',
+    'EA': 'early_access_date',
+    'EY': 'early_access_year',
+    'PG': 'page_count',
+    'P2': 'chapter_count',
+    'WC': 'wos_categories', # ListType
+    'SC': 'research_areas', # ListType
+    'GA': 'document_delivery_number',
+    'PM': 'pubmed_id',
+    'UT': 'accession_number',
+    'OA': 'open_access_indicator',
+    'HP': 'esi_hot_paper',
+    'HC': 'esi_highly_cited_paper',
+    'DA': 'date_generated',
+    'ER': 'end_of_record',
+    'EF': 'end_of_file',
 }

--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -54,7 +54,6 @@ TAG_KEY_MAPPING = {
     'NV': 'number_of_Volumes',
     'OP': 'original_publication',
     'PB': 'publisher',
-    'PT': 'publication_type',
     'PY': 'year',
     'RI': 'reviewed_item',
     'RN': 'research_notes',

--- a/RISparser/parser.py
+++ b/RISparser/parser.py
@@ -146,6 +146,9 @@ class Wok(Base):
 
     def get_content(self, line):
         return line[2:].strip()
+    
+    def is_counter(self, line):
+        return True
 
 
 class Ris(Base):

--- a/RISparser/parser.py
+++ b/RISparser/parser.py
@@ -142,7 +142,7 @@ class Base(object):
 class Wok(Base):
     START_TAG = 'PT'
     IGNORE = ['FN', 'VR', 'EF']
-    PATTERN = '^[A-Z][A-Z0-9] |^ER |^EF '
+    PATTERN = '^[A-Z][A-Z0-9] |^ER\s?|^EF\s?'
 
     def get_content(self, line):
         return line[2:].strip()

--- a/RISparser/parser.py
+++ b/RISparser/parser.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import re
 
-from .config import LIST_TYPE_TAGS, TAG_KEY_MAPPING
+from .config import LIST_TYPE_TAGS, TAG_KEY_MAPPING, WOK_TAG_KEY_MAPPING, WOK_LIST_TYPE_TAGS
 
 
 __all__ = ['readris', 'read']
@@ -143,10 +143,11 @@ class Wok(Base):
     START_TAG = 'PT'
     IGNORE = ['FN', 'VR', 'EF']
     PATTERN = '^[A-Z][A-Z0-9] |^ER\s?|^EF\s?'
+    LIST_TYPE_TAGS = WOK_LIST_TYPE_TAGS
 
     def get_content(self, line):
         return line[2:].strip()
-    
+
     def is_counter(self, line):
         return True
 
@@ -193,10 +194,11 @@ def read(filelines, mapping=None, wok=False):
 
     """
 
-    if not mapping:
-        mapping = TAG_KEY_MAPPING
-
     if wok:
+        if not mapping:
+            mapping = WOK_TAG_KEY_MAPPING
         return Wok(filelines, mapping).parse()
-
-    return Ris(filelines, mapping).parse()
+    else:
+        if not mapping:
+            mapping = TAG_KEY_MAPPING
+        return Ris(filelines, mapping).parse()

--- a/tests/example_wos.ris
+++ b/tests/example_wos.ris
@@ -1,0 +1,258 @@
+FN Clarivate Analytics Web of Science
+VR 1.0
+PT J
+AU Parkes-Loach, PS
+   Majeed, AP
+   Law, CJ
+   Loach, PA
+AF Parkes-Loach, PS
+   Majeed, AP
+   Law, CJ
+   Loach, PA
+TI Interactions stabilizing the structure of the core light-harvesting
+   complex (LHl) of photosynthetic bacteria and its subunit (B820)
+SO BIOCHEMISTRY
+LA English
+DT Article
+ID CHEMICALLY SYNTHESIZED POLYPEPTIDES; IN-VITRO RECONSTITUTION;
+   AMINO-ACID-SEQUENCE; RHODOSPIRILLUM-RUBRUM; RHODOBACTER-SPHAEROIDES;
+   RHODOPSEUDOMONAS-VIRIDIS; BACTERIOCHLOROPHYLL-A; ALPHA-POLYPEPTIDE;
+   CRYSTAL-STRUCTURE; ANTENNA COMPLEX
+AB Reconstitution experiments with a chemically synthesized core light-harvesting (LH1) beta-polypeptide analogue having 3-methylhistidine instead of histidine in the position that normally donates the coordinating ligand to bacteriochlorophyll (Bchl) have provided the experimental data needed to assign to B820 one of the two possible alphabeta.2Bchl pairs that are observed in the crystal structure of LH2 from Phaeospirillum (formerly Rhodospirillum) molischianum, the one with rings III and V of Bchl overlapping. Consistent with the assigned structure, experimental evidence is provided to show that significant stabilizing interactions for both the subunit complex (B820) and LH1 occur between the N-terminal regions of the alpha- and beta-polypeptides. On the basis of the results with the chemically synthesized polypeptides used in this study, along with earlier results with protease-modified polypeptides, mutants, and chemically synthesized polypeptides, the importance of a stretch of 9-13 amino acids at the N-terminal end of the alpha- and beta-polypeptides is underscored. A progressive loss of interaction with the LH1 beta-potypeptide was found as the first three N-terminal amino acids of the LH1 alpha-polypeptide were removed. The absence of the N-terminal formylmethionine (fMet), or conversion of the sulfur in this fMet to the sulfoxide, resulted in a decrease in LH1 formation. In addition to the removal of fMet, removal of the next two amino acids also resulted in a decrease in K-assoc for B820 formation and nearly eliminated the ability to form LH1. It is suggested that the first three amino acids (fMetTrpArg) of the LH1 alpha-polypeptide of Rhodospirillum rubrum form a cluster that is most likely involved in close interaction with the side chain of His -18 (see Figure 1 for numbering of amino acids) of the beta-polypeptide. The results provide evidence that the folding motif of the alpha- and beta-polypeptides in the N-terminal region observed in crystal structures of LH2 is also present in LH1 and contributes significantly to stabilizing the complex.
+C1 Northwestern Univ, Dept Biochem Mol Biol & Cell Biol, Evanston, IL 60208 USA.
+RP Loach, PA (reprint author), Northwestern Univ, Dept Biochem Mol Biol & Cell Biol, Hogan Hall,Room 2-100, Evanston, IL 60208 USA.
+EM p-loach@northwestern.edu
+RI Law, Christopher/E-7174-2011
+CR ALLEN JP, 1986, P NATL ACAD SCI USA, V83, P8589, DOI 10.1073/pnas.83.22.8589
+   Arluison W, 2004, BIOCHEMISTRY-US, V43, P1276, DOI 10.1021/bi030205v
+   BARRICK D, 1994, BIOCHEMISTRY-US, V33, P6546, DOI 10.1021/bi00187a023
+   BERGER G, 1987, J LIQ CHROMATOGR, V10, P1519, DOI 10.1080/01483918708066784
+   BRUNISHOLZ RA, 1984, H-S Z PHYSIOL CHEM, V365, P675, DOI 10.1515/bchm2.1984.365.2.675
+   BRUNISHOLZ RA, 1981, FEBS LETT, V129, P150, DOI 10.1016/0014-5793(81)80778-8
+   CHANG CH, 1986, FEBS LETT, V205, P82, DOI 10.1016/0014-5793(86)80870-5
+   CHANG MC, 1990, PHOTOCHEM PHOTOBIOL, V52, P873, DOI 10.1111/j.1751-1097.1990.tb08696.x
+   CHANG MC, 1990, BIOCHEMISTRY-US, V29, P421, DOI 10.1021/bi00454a017
+   DAVIS CM, 1995, J BIOL CHEM, V270, P5793, DOI 10.1074/jbc.270.11.5793
+   Davis CM, 1997, BIOCHEMISTRY-US, V36, P3671, DOI 10.1021/bi962386p
+   DEISENHOFER J, 1984, J MOL BIOL, V180, P385, DOI 10.1016/S0022-2836(84)80011-X
+   DERFELD CA, 1994, BIOCHIM BIOPHYS ACTA, V1185, P193
+   Francia F, 1999, BIOCHEMISTRY-US, V38, P6834, DOI 10.1021/bi982891h
+   Francia F, 2002, EUR J BIOCHEM, V269, P1877, DOI 10.1046/j.1432-1033.2002.02834.x
+   Frese RN, 2000, P NATL ACAD SCI USA, V97, P5197, DOI 10.1073/pnas.090083797
+   Goldsmith JO, 1996, BIOCHEMISTRY-US, V35, P2421, DOI 10.1021/bi9523365
+   HELLER BA, 1990, PHOTOCHEM PHOTOBIOL, V51, P621, DOI 10.1111/j.1751-1097.1990.tb01975.x
+   Hu XC, 2002, Q REV BIOPHYS, V35, P1, DOI 10.1017/S0033583501003754
+   Jamieson SJ, 2002, EMBO J, V21, P3927, DOI 10.1093/emboj/cdf410
+   JIRSAKOVA V, 1993, BIOCHIM BIOPHYS ACTA, V1183, P301, DOI 10.1016/0005-2728(93)90231-4
+   Jungas C, 1999, EMBO J, V18, P534, DOI 10.1093/emboj/18.3.534
+   KARRASCH S, 1995, EMBO J, V14, P631, DOI 10.1002/j.1460-2075.1995.tb07041.x
+   Kehoe JW, 1998, BIOCHEMISTRY-US, V37, P3418, DOI 10.1021/bi9722709
+   Koepke J, 1996, STRUCTURE, V4, P581, DOI 10.1016/S0969-2126(96)00063-9
+   Law CJ, 2003, PHOTOSYNTH RES, V75, P193, DOI 10.1023/A:1023982327748
+   LEE JK, 1989, J BACTERIOL, V171, P3391, DOI 10.1128/jb.171.6.3391-3405.1989
+   LILBURN TG, 1995, J BACTERIOL, V177, P4593, DOI 10.1128/jb.177.16.4593-4600.1995
+   LOACH PA, 1990, FEMS SYMP, V53, P235
+   LOACH PA, 1994, PHOTOSYNTH RES, V40, P231, DOI 10.1007/BF00034773
+   LOACH PA, 1995, ANOXYGENIC PHOTOSYNT, P437
+   LOACH PA, 1985, MOL BIOL PHOTOSYNTHE, P197
+   MCDERMOTT G, 1995, NATURE, V374, P517, DOI 10.1038/374517a0
+   McGlynn P, 1996, J BIOL CHEM, V271, P3285, DOI 10.1074/jbc.271.6.3285
+   Meadows KA, 1998, BIOCHEMISTRY-US, V37, P3411, DOI 10.1021/bi972269+
+   MEADOWS KA, 1995, BIOCHEMISTRY-US, V34, P1559, DOI 10.1021/bi00005a012
+   MECKENSTOCK RU, 1992, FEBS LETT, V311, P128, DOI 10.1016/0014-5793(92)81383-W
+   MICHALSKI TJ, 1988, J AM CHEM SOC, V110, P5888, DOI 10.1021/ja00225a047
+   MILLER JF, 1987, BIOCHEMISTRY-US, V26, P5055, DOI 10.1021/bi00390a026
+   Papiz MZ, 1996, TRENDS PLANT SCI, V1, P198, DOI 10.1016/1360-1385(96)20005-6
+   Parkes-Loach PS, 2001, BIOCHEMISTRY-US, V40, P5593, DOI 10.1021/bi002580i
+   PARKESLOACH PS, 1994, PHOTOSYNTH RES, V40, P247, DOI 10.1007/BF00034774
+   PARKESLOACH PS, 1988, BIOCHEMISTRY-US, V27, P2718, DOI 10.1021/bi00408a011
+   Pond AE, 2000, INORG CHEM, V39, P6061, DOI 10.1021/ic0007198
+   Roszak AW, 2003, SCIENCE, V302, P1969, DOI 10.1126/science.1088892
+   Scheuring S, 2003, P NATL ACAD SCI USA, V100, P1690, DOI 10.1073/pnas.0437992100
+   THEILER R, 1984, H-S Z PHYSIOL CHEM, V365, P703, DOI 10.1515/bchm2.1984.365.2.703
+   Todd JB, 1998, BIOCHEMISTRY-US, V37, P17458, DOI 10.1021/bi981114e
+   Todd JB, 1999, PHOTOSYNTH RES, V62, P85, DOI 10.1023/A:1006337827672
+   TONN SJ, 1977, BIOCHEMISTRY-US, V16, P877, DOI 10.1021/bi00624a011
+   VANGRONDELLE R, 1994, BBA-BIOENERGETICS, V1187, P1, DOI 10.1016/0005-2728(94)90166-X
+   VANMOURIK F, 1991, BIOCHIM BIOPHYS ACTA, V1059, P111, DOI 10.1016/S0005-2728(05)80193-8
+   VISSCHERS RW, 1991, BIOCHEMISTRY-US, V30, P5734, DOI 10.1021/bi00237a015
+   VISSCHERS RW, 1993, BIOCHIM BIOPHYS ACTA, V1183, P369, DOI 10.1016/0005-2728(93)90241-7
+   Walz T, 1997, J MOL BIOL, V265, P107, DOI 10.1006/jmbi.1996.0714
+   Wang ZY, 2002, J AM CHEM SOC, V124, P1072, DOI 10.1021/ja0112994
+   Wang ZY, 2001, EUR J BIOCHEM, V268, P3375, DOI 10.1046/j.1432-1327.2001.02234.x
+   Westerhuis WHJ, 1998, BBA-BIOENERGETICS, V1366, P317, DOI 10.1016/S0005-2728(98)00132-7
+   ZUBER H, 1995, ANOXYGENIC PHOTOSYNT, P315
+NR 59
+TC 23
+Z9 25
+U1 0
+U2 5
+PU AMER CHEMICAL SOC
+PI WASHINGTON
+PA 1155 16TH ST, NW, WASHINGTON, DC 20036 USA
+SN 0006-2960
+J9 BIOCHEMISTRY-US
+JI Biochemistry
+PD JUN 8
+PY 2004
+VL 43
+IS 22
+BP 7003
+EP 7016
+DI 10.1021/bi049798f
+PG 14
+WC Biochemistry & Molecular Biology
+SC Biochemistry & Molecular Biology
+GA 826CV
+UT WOS:000221807500019
+PM 15170338
+DA 2019-03-18
+ER
+
+PT J
+AU Cao, WX
+   Ye, X
+   Georgiev, GY
+   Berezhna, S
+   Sjodin, T
+   Demidov, AA
+   Wang, W
+   Sage, JT
+   Champion, PM
+AF Cao, WX
+   Ye, X
+   Georgiev, GY
+   Berezhna, S
+   Sjodin, T
+   Demidov, AA
+   Wang, W
+   Sage, JT
+   Champion, PM
+TI Proximal and distal influences on ligand binding kinetics in
+   microperoxidase and heme model compounds
+SO BIOCHEMISTRY
+LA English
+DT Article
+ID SPERM-WHALE MYOGLOBIN; RESONANCE RAMAN-SCATTERING; CARBON-MONOXIDE
+   BINDING; POCKET DOCKING SITE; T-STATE HEMOGLOBIN; CYTOCHROME-C; GEMINATE
+   RECOMBINATION; LOW PH; VIBRATIONAL-RELAXATION; QUATERNARY STRUCTURE
+AB We use laser flash photolysis and time-resolved Raman spectroscopy of CO-bound heme complexes to study proximal and distal influences on ligand rebinding kinetics. We report kinetics of CO rebinding to microperoxidase (MP) and 2-methylimidazole ligated Fe protoporphyrin IX in the 10 ns to 10 ms time window. We also report CO rebinding kinetics of MP in the 150 fs to 140 ps time window. For dilute, micelle-encapsulated (monodisperse) samples of MP, we do not observe the large amplitude geminate decay at similar to100 ps previously reported in time-resolved IR measurements on highly concentrated samples [Lim, M., Jackson, T. A., and Anfinrud, P. A. (1997) J. Biol. Inorg. Chem. 2, 531-536]. However, for high concentration aggregated samples, we do observe the large amplitude picosecond CO geminate rebinding and find that it is correlated with the absence of the iron-histidine vibrational mode in the time-resolved Raman spectrum. On the basis of these results, the energetic significance of a putative distal pocket CO docking site proposed by Lim et al. may need to be reconsidered. Finally, when high concentration samples of native myoglobin (Mb) were studied as a control, an analogous increase in the geminate rebinding kinetics was not observed. This verifies that studies of Mb under dilute conditions are applicable to the more concentrated regime found in the cellular milieu.
+C1 Northeastern Univ, Dept Phys, Boston, MA 02115 USA.
+   Northeastern Univ, Ctr Interdisciplinary Res Complex Syst, Boston, MA 02115 USA.
+RP Champion, PM (reprint author), Northeastern Univ, Dept Phys, Boston, MA 02115 USA.
+EM jtsage@neu.edu; p.champion@neu.edu
+FU NIGMS NIH HHS [GM-52002]; NIDDK NIH HHS [DK035090]
+CR Adams P. A., 1996, CYTOCHROME C MULTIDI, P635
+   ANFINRUD PA, 1994, P SOC PHOTO-OPT INS, V2138, P107, DOI 10.1117/12.181348
+   Antonini E., 1971, HEMOGLOBIN MYOGLOBIN
+   AUSTIN RH, 1975, BIOCHEMISTRY-US, V14, P5355, DOI 10.1021/bi00695a021
+   BANGCHAROENPAURPONG O, 1984, J AM CHEM SOC, V106, P5688, DOI 10.1021/ja00331a045
+   Barrick D, 1997, NAT STRUCT BIOL, V4, P78, DOI 10.1038/nsb0197-78
+   BLAUER G, 1993, BIOCHEMISTRY-US, V32, P6674, DOI 10.1021/bi00077a021
+   Brunori M, 2000, P NATL ACAD SCI USA, V97, P2058, DOI 10.1073/pnas.040459697
+   Brunori M, 2000, BIOPHYS CHEM, V86, P221, DOI 10.1016/S0301-4622(00)00142-3
+   CAO W, 2003, THESIS NE U BOSTON
+   Cao WX, 2001, BIOPHYS J, V80, p283A
+   Cao WX, 2001, BIOCHEMISTRY-US, V40, P5728, DOI 10.1021/bi010067e
+   CARRAWAY AD, 1995, J INORG BIOCHEM, V60, P267, DOI 10.1016/0162-0134(95)00026-7
+   CARVER TE, 1990, J BIOL CHEM, V265, P20007
+   CHANCE B, 1966, J MOL BIOL, V17, P525, DOI 10.1016/S0022-2836(66)80162-6
+   CHANG CK, 1973, J AM CHEM SOC, V95, P8477, DOI 10.1021/ja00806a062
+   Christian JF, 1997, BIOCHEMISTRY-US, V36, P11198, DOI 10.1021/bi9710075
+   Chu K, 2000, NATURE, V403, P921
+   DUPRAT AF, 1995, BIOCHEMISTRY-US, V34, P2634, DOI 10.1021/bi00008a030
+   ELBER R, 1990, J AM CHEM SOC, V112, P9161, DOI 10.1021/ja00181a020
+   Franzen S, 2001, BIOCHEMISTRY-US, V40, P5299, DOI 10.1021/bi0023403
+   GEIBEL J, 1978, J AM CHEM SOC, V100, P3575, DOI 10.1021/ja00479a047
+   Harvey JN, 2000, J AM CHEM SOC, V122, P12401, DOI 10.1021/ja005543n
+   HASINOFF BB, 1981, ARCH BIOCHEM BIOPHYS, V211, P396, DOI 10.1016/0003-9861(81)90470-7
+   HENRY ER, 1983, J MOL BIOL, V166, P443, DOI 10.1016/S0022-2836(83)80094-1
+   HORI H, 1980, J AM CHEM SOC, V102, P3608, DOI 10.1021/ja00530a049
+   HUANG Y, 1991, J AM CHEM SOC, V113, P9141, DOI 10.1021/ja00024a018
+   KINCAID J, 1979, P NATL ACAD SCI USA, V76, P549, DOI 10.1073/pnas.76.2.549
+   Kumazaki S, 2000, J BIOL CHEM, V275, P38378, DOI 10.1074/jbc.M005533200
+   Kundu S, 2002, PROTEINS, V46, P268, DOI 10.1002/prot.10048
+   Laberge M, 1998, J BIOMOL STRUCT DYN, V15, P1039, DOI 10.1080/07391102.1998.10508999
+   LI XY, 1988, J AM CHEM SOC, V110, P6024, DOI 10.1021/ja00226a017
+   LIM M, 1995, SCIENCE, V269, P962, DOI 10.1126/science.7638619
+   LIM M, 2001, ULTRAFAST INFRARED R, P191
+   Lim MH, 1997, J BIOL INORG CHEM, V2, P531, DOI 10.1007/s007750050167
+   LIM MH, 1995, J CHEM PHYS, V102, P4355, DOI 10.1063/1.469484
+   Lim MH, 1997, NAT STRUCT BIOL, V4, P209, DOI 10.1038/nsb0397-209
+   Linke W. F., 1940, SOLUBILITIES INORGAN
+   MAZUMDAR S, 1991, INORG CHEM, V30, P700, DOI 10.1021/ic00004a020
+   McMahon BH, 2000, J CHEM PHYS, V113, P6831, DOI 10.1063/1.1309524
+   MIERS JB, 1991, J CHEM PHYS, V94, P1825, DOI 10.1063/1.459957
+   NAGAI K, 1980, J MOL BIOL, V136, P271, DOI 10.1016/0022-2836(80)90374-5
+   Negrerie M, 2001, J BIOL CHEM, V276, P46815, DOI 10.1074/jbc.M102224200
+   Olson JS, 1997, J BIOL INORG CHEM, V2, P544, DOI 10.1007/s007750050169
+   Olson JS, 1996, J BIOL CHEM, V271, P17593, DOI 10.1074/jbc.271.30.17593
+   OLSON JS, 1988, NATURE, V336, P265, DOI 10.1038/336265a0
+   Ostermann A, 2000, NATURE, V404, P205, DOI 10.1038/35004622
+   OTHMAN S, 1993, BIOCHEMISTRY-US, V32, P9781, DOI 10.1021/bi00088a033
+   PERUTZ MF, 1970, NATURE, V228, P726, DOI 10.1038/228726a0
+   PERUTZ MF, 1966, J MOL BIOL, V21, P199, DOI 10.1016/0022-2836(66)90088-X
+   Peterson ES, 1998, BIOCHEMISTRY-US, V37, P4346, DOI 10.1021/bi9708693
+   PHILLIPS SEV, 1980, J MOL BIOL, V142, P531, DOI 10.1016/0022-2836(80)90262-4
+   QUILLIN ML, 1993, J MOL BIOL, V234, P140, DOI 10.1006/jmbi.1993.1569
+   RAY GB, 1994, J AM CHEM SOC, V116, P162, DOI 10.1021/ja00080a019
+   RINGE D, 1984, BIOCHEMISTRY-US, V23, P2, DOI 10.1021/bi00296a001
+   ROUSSEAU DL, 1988, RESONANCE RAMAN SPEC, P133
+   SAGE JT, 1991, BIOCHEMISTRY-US, V30, P1227, DOI 10.1021/bi00219a010
+   SAGE JT, 1991, BIOCHEMISTRY-US, V30, P1237, DOI 10.1021/bi00219a011
+   SAGE JT, 1996, COMPREHENSIVE SUPRAM, V5, P171
+   SAGE JT, 2004, ENCY SUPRAMOLECULAR
+   SALMEEN I, 1978, BIOCHEMISTRY-US, V17, P800, DOI 10.1021/bi00598a008
+   Scott EE, 1997, BIOCHEMISTRY-US, V36, P11909, DOI 10.1021/bi970719s
+   Scott EE, 2001, J BIOL CHEM, V276, P5177, DOI 10.1074/jbc.M008282200
+   SHARMA VS, 1975, BIOCHEM BIOPH RES CO, V66, P1301, DOI 10.1016/0006-291X(75)90501-X
+   Sigfridsson E, 2002, J INORG BIOCHEM, V91, P101, DOI 10.1016/S0162-0134(02)00426-9
+   Spiro TG, 2001, ACCOUNTS CHEM RES, V34, P137, DOI 10.1021/ar0001108j
+   SRAJER V, 1988, J AM CHEM SOC, V110, P6656, DOI 10.1021/ja00228a009
+   Sugimoto T, 1998, BIOPHYS J, V75, P2188, DOI 10.1016/S0006-3495(98)77662-3
+   TERAOKA J, 1981, J BIOL CHEM, V256, P3969
+   Tian WD, 1996, BIOCHEMISTRY-US, V35, P3487, DOI 10.1021/bi952474u
+   TRAYLOR TG, 1981, ACCOUNTS CHEM RES, V14, P102, DOI 10.1021/ar00064a002
+   TRAYLOR TG, 1990, J AM CHEM SOC, V112, P6875, DOI 10.1021/ja00175a022
+   TRAYLOR TG, 1992, J AM CHEM SOC, V114, P417, DOI 10.1021/ja00028a005
+   Unno M, 1998, J AM CHEM SOC, V120, P2670, DOI 10.1021/ja973293d
+   URRY DW, 1967, J AM CHEM SOC, V89, P5276, DOI 10.1021/ja00996a034
+   URRY DW, 1967, J AM CHEM SOC, V89, P4190, DOI 10.1021/ja00992a601
+   Vogel KM, 1999, J AM CHEM SOC, V121, P9915, DOI 10.1021/ja990042r
+   WANG JS, 1989, J PHYS CHEM-US, V93, P7925, DOI 10.1021/j100360a038
+   Wang W, 2000, J PHYS CHEM B, V104, P10789, DOI 10.1021/jp0008602
+   WEI YZ, 1994, J PHYS CHEM-US, V98, P6644, DOI 10.1021/j100077a034
+   WHITE DK, 1979, J AM CHEM SOC, V101, P2443, DOI 10.1021/ja00503a034
+   Yang F, 1996, J MOL BIOL, V256, P762, DOI 10.1006/jmbi.1996.0123
+   Ye X, 2002, J AM CHEM SOC, V124, P5914, DOI 10.1021/ja017359n
+   YE X, 2003, THESIS NE U BOSTON
+   Ye XO, 2003, J PHYS CHEM A, V107, P8156, DOI 10.1021/jp0276799
+   ZHU L, 1992, J MOL BIOL, V224, P207, DOI 10.1016/0022-2836(92)90584-7
+NR 86
+TC 31
+Z9 31
+U1 1
+U2 13
+PU AMER CHEMICAL SOC
+PI WASHINGTON
+PA 1155 16TH ST, NW, WASHINGTON, DC 20036 USA
+SN 0006-2960
+J9 BIOCHEMISTRY-US
+JI Biochemistry
+PD JUN 8
+PY 2004
+VL 43
+IS 22
+BP 7017
+EP 7027
+DI 10.1021/bi0497291
+PG 11
+WC Biochemistry & Molecular Biology
+SC Biochemistry & Molecular Biology
+GA 826CV
+UT WOS:000221807500020
+PM 15170339
+DA 2019-03-18
+ER
+
+EF

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -173,3 +173,9 @@ class TestRISparser():
         with open(fn, 'r') as f:
             entries = list(readris(f))
         assert len(entries) == 1
+
+    def test_parse_wos_ris(self):
+        fn = os.path.join(CURRENT_DIR, 'example_wos.ris')
+        with open(fn, 'r') as f:
+            entries = list(readris(f, wok=True))
+        assert len(entries) == 2


### PR DESCRIPTION
When I tried to parse a ris file downloaded from Web of Science using RISparser 0.4.3, it fails for several reasons: 

1. It doesn't recognize the PT start tag. It throws a "KEY exception". 
2. It couldn't find the "is_counter" function in the Wok class
3. It fails to find the "ET" and "ER" tags if they don't have a trailing space. 

This pull request would solve the issues mentioned above. 