### PR TITLE
Replace N2 'abstract' by 'notes_abstract' to avoid conflicts

### DIFF
--- a/RISparser/config.py
+++ b/RISparser/config.py
@@ -50,7 +50,7 @@ TAG_KEY_MAPPING = {
     'M1': 'note',
     'M3': 'type_of_work',
     'N1': 'notes',  # ListType
-    'N2': 'abstract',
+    'N2': 'notes_abstract',
     'NV': 'number_of_Volumes',
     'OP': 'original_publication',
     'PB': 'publisher',


### PR DESCRIPTION
One duplicate label is found in the tag map. This makes rendering the `dict` problematic/impossible in some situations. 

```
In [1]: from RISparser.config import TAG_KEY_MAPPING                                                               

In [2]: len(TAG_KEY_MAPPING)                                                                                      
Out[2]: 65

In [3]: len(set([k for k,v in TAG_KEY_MAPPING.items()]))                                                          
Out[3]: 65

In [4]: len(set([v for k,v in TAG_KEY_MAPPING.items()]))                                                          
Out[4]: 64

```